### PR TITLE
Added mysql configuration file. Adds compatibility with latest version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
             - mysql
 
     mysql:
-        image: mysql:latest
+        build: ./mysql/
         volumes:
             - data:/var/lib/mysql
         networks:

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:latest
+
+COPY ./my.cnf /etc/mysql/conf.d/my.cnf

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
**Issue:** It seems there is a problem when trying to connect to the database with the last version of MySQL. 

**Solution:** create a configuration file that sets the default authentication plugin to mysql_native_password.
Reference: https://mysqlserverteam.com/upgrading-to-mysql-8-0-default-authentication-plugin-considerations/

May fix the issue #1. 